### PR TITLE
german 10-digit account numbers

### DIFF
--- a/src/IbanValidator/IbanValidator/Specialized/Germany/GermanyIbanInformationProvider.cs
+++ b/src/IbanValidator/IbanValidator/Specialized/Germany/GermanyIbanInformationProvider.cs
@@ -11,7 +11,7 @@ namespace IbanValidator.Specialized.Germany
             : base(iban)
         {
             const int blzLength = 8;
-            const int ktoLength = 8;
+            const int ktoLength = 10;
 
             // DE00 2105 0170 0012 3456 78
             //      210 501 70 - 0012 3456 78

--- a/src/IbanValidator/IbanValidator/Specialized/Germany/Kontonummer.cs
+++ b/src/IbanValidator/IbanValidator/Specialized/Germany/Kontonummer.cs
@@ -7,7 +7,7 @@ namespace IbanValidator.Specialized.Germany
         public long Value { get; }
         public Kontonummer(long kto)
         {
-            if (kto > 999999999 || kto < 10000000)
+            if (kto > 9999999999 || kto < 10000000)
                 throw new ArgumentException($"Invalid {nameof(kto)}");
             Value = kto;
         }


### PR DESCRIPTION
Current code implies that german account numbers can only consist of 8 digits, which ist not true, it's actually 10 digits (see [https://de.wikipedia.org/wiki/Kontonummer#Deutschland](https://de.wikipedia.org/wiki/Kontonummer#Deutschland))